### PR TITLE
Disable chrony in warden containers

### DIFF
--- a/src/github.com/cppforlife/bosh-warden-cpi/vm/warden_creator.go
+++ b/src/github.com/cppforlife/bosh-warden-cpi/vm/warden_creator.go
@@ -205,6 +205,7 @@ func (c WardenCreator) startAgentInContainer(container wrdn.Container) error {
 				"umount /etc/hostname",
 				"rm -rf /var/vcap/data/sys",
 				"mkdir -p /var/vcap/data/sys",
+				"sed -i 's/chronyc/# chronyc/g' /var/vcap/bosh/bin/sync-time",
 				"exec env -i /usr/sbin/runsvdir-start",
 			}, "\n"),
 		},

--- a/src/github.com/cppforlife/bosh-warden-cpi/vm/warden_creator_test.go
+++ b/src/github.com/cppforlife/bosh-warden-cpi/vm/warden_creator_test.go
@@ -323,6 +323,7 @@ var _ = Describe("WardenCreator", func() {
 									"umount /etc/hostname",
 									"rm -rf /var/vcap/data/sys",
 									"mkdir -p /var/vcap/data/sys",
+									"sed -i 's/chronyc/# chronyc/g' /var/vcap/bosh/bin/sync-time",
 									"exec env -i /usr/sbin/runsvdir-start",
 								}, "\n"),
 							},


### PR DESCRIPTION
During agent bootstrap it runs /var/vcap/bosh/bin/sync-time
Which executes `chronyc waitsync 10` which in turn hangs for 90s
because it can not reach the chronyd daemon:
```
debug/af1c3007-06ef-43ce-bf40-9d5e3e4080e6:~# chronyc waitsync 10
506 Cannot talk to daemon
506 Cannot talk to daemon
506 Cannot talk to daemon
506 Cannot talk to daemon
506 Cannot talk to daemon
506 Cannot talk to daemon
506 Cannot talk to daemon
```

This daemon is not running because there is no systemd in containers.
```
debug/af1c3007-06ef-43ce-bf40-9d5e3e4080e6:~# systemctl restart chrony.service
System has not been booted with systemd as init system (PID 1). Can't operate.
```

Long story short, we actually don't need to sync time in a container since it shares the time with the host ([can only change the time when running privileged](https://stackoverflow.com/questions/22800624/will-a-docker-container-auto-sync-time-with-its-host-machine#comment34898836_22820278)).

The solution is to comment out invocations of chronyc in the sync-time script during container start.