### PR TITLE
Add start_containers_with_systemd for running Noble stemcell containers

### DIFF
--- a/jobs/warden_cpi/spec
+++ b/jobs/warden_cpi/spec
@@ -6,6 +6,7 @@ templates:
   cpi_ctl.erb: bin/cpi_ctl
   cpi.json.erb: config/cpi.json
   sudoers: config/sudoers
+  pre-start.erb: bin/pre-start
 
 packages:
 - warden_cpi
@@ -74,3 +75,7 @@ properties:
   warden_cpi.actions.guest_persistent_bind_mounts_dir:
     description: "Directory with sub-directories at which persistent disks are mounted inside VMs"
     default: "/warden-cpi-dev"
+
+  warden_cpi.start_containers_with_systemd:
+    description: "Containers will use /sbin/init as the entry point. Enabling this is required for Noble stemcells, but currently breaks all pre-Noble stemcells"
+    default: false

--- a/jobs/warden_cpi/templates/cpi.json.erb
+++ b/jobs/warden_cpi/templates/cpi.json.erb
@@ -1,5 +1,6 @@
 <%=
 JSON.dump(
+  "start_containers_with_systemd" => p("warden_cpi.start_containers_with_systemd"),
   "Warden" => {
     "ConnectNetwork" => p("warden_cpi.warden.connect_network"),
     "ConnectAddress" => p("warden_cpi.warden.connect_address"),

--- a/jobs/warden_cpi/templates/pre-start.erb
+++ b/jobs/warden_cpi/templates/pre-start.erb
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -eu
+
+<% if p("warden_cpi.start_containers_with_systemd") %>
+sed -i 's/\/var\/vcap\/data\/garden\/bin\/init/\/sbin\/init/' /var/vcap/jobs/garden/config/config.ini
+<% else %>
+sed -i 's/\/sbin\/init/\/var\/vcap\/data\/garden\/bin\/init/' /var/vcap/jobs/garden/config/config.ini
+<% end %>

--- a/src/bosh-warden-cpi/action/factory.go
+++ b/src/bosh-warden-cpi/action/factory.go
@@ -8,6 +8,7 @@ import (
 	boshsys "github.com/cloudfoundry/bosh-utils/system"
 	boshuuid "github.com/cloudfoundry/bosh-utils/uuid"
 
+	. "bosh-warden-cpi/config"
 	bwcdisk "bosh-warden-cpi/disk"
 	bwcstem "bosh-warden-cpi/stemcell"
 	bwcutil "bosh-warden-cpi/util"
@@ -56,6 +57,7 @@ func NewFactory(
 	uuidGen boshuuid.Generator,
 	opts FactoryOpts,
 	logger boshlog.Logger,
+	config Config,
 ) Factory {
 	var decompressor bwcutil.Decompressor
 	if opts.ExpandStemcellTarball {
@@ -91,7 +93,7 @@ func NewFactory(
 
 	vmCreator := bwcvm.NewWardenCreator(
 		uuidGen, wardenClient, metadataService, agentEnvServiceFactory, ports,
-		hostBindMounts, guestBindMounts, systemResolvConfProvider, opts.Agent, logger)
+		hostBindMounts, guestBindMounts, systemResolvConfProvider, opts.Agent, logger, config)
 
 	vmFinder := bwcvm.NewWardenFinder(
 		wardenClient, agentEnvServiceFactory, ports, hostBindMounts, guestBindMounts, logger)

--- a/src/bosh-warden-cpi/config/config.go
+++ b/src/bosh-warden-cpi/config/config.go
@@ -1,18 +1,18 @@
-package main
+package config
 
 import (
 	"encoding/json"
 
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	boshsys "github.com/cloudfoundry/bosh-utils/system"
-
-	bwcaction "bosh-warden-cpi/action"
 )
 
 type Config struct {
 	Warden WardenConfig
 
-	Actions bwcaction.FactoryOpts
+	Actions FactoryOpts
+
+	StartContainersWithSystemD bool `json:"start_containers_with_systemd"`
 }
 
 type WardenConfig struct {

--- a/src/bosh-warden-cpi/config/config_suite_test.go
+++ b/src/bosh-warden-cpi/config/config_suite_test.go
@@ -1,0 +1,13 @@
+package config_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfigPackage(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Config Suite")
+}

--- a/src/bosh-warden-cpi/config/config_test.go
+++ b/src/bosh-warden-cpi/config/config_test.go
@@ -1,15 +1,13 @@
-package main_test
+package config_test
 
 import (
+	. "bosh-warden-cpi/config"
 	"errors"
 
 	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
 	fakesys "github.com/cloudfoundry/bosh-utils/system/fakes"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	bwcaction "bosh-warden-cpi/action"
-	. "bosh-warden-cpi/main"
 )
 
 var validConfig = Config{
@@ -22,7 +20,7 @@ var validWardenConfig = WardenConfig{
 	ConnectAddress: "fake-address",
 }
 
-var validActionsOptions = bwcaction.FactoryOpts{
+var validActionsOptions = FactoryOpts{
 	StemcellsDir: "/tmp/stemcells",
 	DisksDir:     "/tmp/disks",
 

--- a/src/bosh-warden-cpi/config/factory_opts.go
+++ b/src/bosh-warden-cpi/config/factory_opts.go
@@ -1,4 +1,4 @@
-package action
+package config
 
 import (
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"

--- a/src/bosh-warden-cpi/config/factory_opts_test.go
+++ b/src/bosh-warden-cpi/config/factory_opts_test.go
@@ -1,11 +1,11 @@
-package action_test
+package config_test
 
 import (
 	"github.com/cloudfoundry/bosh-cpi-go/apiv1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	. "bosh-warden-cpi/action"
+	. "bosh-warden-cpi/config"
 )
 
 var _ = Describe("FactoryOpts", func() {

--- a/src/bosh-warden-cpi/main/main.go
+++ b/src/bosh-warden-cpi/main/main.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"os"
 
+	. "bosh-warden-cpi/config"
+
 	wrdnclient "code.cloudfoundry.org/garden/client"
 	wrdnconn "code.cloudfoundry.org/garden/client/connection"
 	"github.com/cloudfoundry/bosh-cpi-go/rpc"
@@ -34,7 +36,7 @@ func main() {
 	wardenClient := wrdnclient.New(wardenConn)
 
 	cpiFactory := bwcaction.NewFactory(
-		wardenClient, fs, cmdRunner, uuidGen, config.Actions, logger)
+		wardenClient, fs, cmdRunner, uuidGen, config.Actions, logger, config)
 
 	cli := rpc.NewFactory(logger).NewCLI(cpiFactory)
 


### PR DESCRIPTION
Currently mixed mode is not supported because the config.ini from garden needs to be modified to change the entrypoint of the container.

So this property will need to be enabled for Noble, but that will prevent older stemcell lines from working.