### PR TITLE
Fix race condition when uploading/downloading vm files

### DIFF
--- a/src/bosh-warden-cpi/vm/warden_file_service.go
+++ b/src/bosh-warden-cpi/vm/warden_file_service.go
@@ -3,6 +3,7 @@ package vm
 import (
 	"archive/tar"
 	"bytes"
+	"crypto/rand"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -30,7 +31,8 @@ func NewWardenFileService(container wrdn.Container, logger boshlog.Logger) Warde
 
 func (s *wardenFileService) Download(sourcePath string) ([]byte, error) {
 	sourceFileName := filepath.Base(sourcePath)
-	tmpFilePath := filepath.Join("/tmp", sourceFileName)
+	tmpFileName := uniqueTmpFileName(sourceFileName)
+	tmpFilePath := filepath.Join("/tmp", tmpFileName)
 
 	s.logger.Debug(s.logTag, "Downloading file at %s", sourcePath)
 
@@ -72,11 +74,11 @@ func (s *wardenFileService) Download(sourcePath string) ([]byte, error) {
 func (s *wardenFileService) Upload(destinationPath string, contents []byte) error {
 	s.logger.Debug(s.logTag, "Uploading file to %s", destinationPath)
 
-	destinationFileName := filepath.Base(destinationPath)
+	tmpFileName := uniqueTmpFileName(filepath.Base(destinationPath))
 
 	// Stream in settings file to a temporary directory
 	// so that tar (running as vcap) has permission to unpack into dir.
-	tarReader, err := s.tarReader(destinationFileName, contents)
+	tarReader, err := s.tarReader(tmpFileName, contents)
 	if err != nil {
 		return bosherr.WrapError(err, "Creating tar")
 	}
@@ -92,8 +94,7 @@ func (s *wardenFileService) Upload(destinationPath string, contents []byte) erro
 		return bosherr.WrapError(err, "Streaming in tar")
 	}
 
-	tmpFilePath := filepath.Join("/tmp", destinationFileName)
-	// Move settings file to its final location
+	tmpFilePath := filepath.Join("/tmp", tmpFileName)
 	script := fmt.Sprintf(
 		"mv %s %s",
 		tmpFilePath,
@@ -135,6 +136,14 @@ func (s *wardenFileService) runPrivilegedScript(script string) error {
 	}
 
 	return nil
+}
+
+func uniqueTmpFileName(baseName string) string {
+	b := make([]byte, 8)
+	_, _ = rand.Read(b)
+	ext := filepath.Ext(baseName)
+	name := baseName[:len(baseName)-len(ext)]
+	return fmt.Sprintf("%s-%x%s", name, b, ext)
 }
 
 func (s *wardenFileService) tarReader(fileName string, contents []byte) (io.Reader, error) {

--- a/src/bosh-warden-cpi/vm/warden_file_service_test.go
+++ b/src/bosh-warden-cpi/vm/warden_file_service_test.go
@@ -55,7 +55,7 @@ var _ = Describe("WardenFileService", func() {
 			wardenConn.RunReturns(runProcess, nil)
 		})
 
-		It("places content into the container at /tmp/destination", func() {
+		It("places content into the container at /tmp/destination with a unique name", func() {
 			err := wardenFileService.Upload("/var/vcap/file.ext", []byte("fake-contents"))
 			Expect(err).ToNot(HaveOccurred())
 
@@ -71,7 +71,7 @@ var _ = Describe("WardenFileService", func() {
 
 			header, err := tarStream.Next()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(header.Name).To(Equal("file.ext")) // todo more?
+			Expect(header.Name).To(MatchRegexp(`^file-[0-9a-f]+\.ext$`))
 
 			contentBytes := make([]byte, header.Size)
 
@@ -91,15 +91,13 @@ var _ = Describe("WardenFileService", func() {
 				count := wardenConn.RunCallCount()
 				Expect(count).To(Equal(1))
 
-				expectedProcessSpec := wrdn.ProcessSpec{
-					Path: "bash",
-					Args: []string{"-c", "mv /tmp/file.ext /var/vcap/file.ext"},
-					User: "root",
-				}
-
 				handle, processSpec, _ := wardenConn.RunArgsForCall(0)
 				Expect(handle).To(Equal("fake-vm-id"))
-				Expect(processSpec).To(Equal(expectedProcessSpec))
+				Expect(processSpec.Path).To(Equal("bash"))
+				Expect(processSpec.User).To(Equal("root"))
+				Expect(processSpec.Args).To(HaveLen(2))
+				Expect(processSpec.Args[0]).To(Equal("-c"))
+				Expect(processSpec.Args[1]).To(MatchRegexp(`^mv /tmp/file-[0-9a-f]+\.ext /var/vcap/file\.ext$`))
 			})
 
 			Context("when moving the temporary file into the final location fails because command exits with non-0 code", func() {
@@ -191,22 +189,22 @@ var _ = Describe("WardenFileService", func() {
 			wardenConn.StreamOutReturns(makeValidAgentEnvTar(), nil)
 		})
 
-		It("copies agent env into temporary location", func() {
+		It("copies agent env into temporary location with a unique name", func() {
 			_, err := wardenFileService.Download("/fake-download-path/file.ext")
 			Expect(err).ToNot(HaveOccurred())
 
 			count := wardenConn.RunCallCount()
 			Expect(count).To(Equal(1))
 
-			expectedProcessSpec := wrdn.ProcessSpec{
-				Path: "bash",
-				Args: []string{"-c", "cp /fake-download-path/file.ext /tmp/file.ext && chown vcap:vcap /tmp/file.ext"},
-				User: "root",
-			}
-
 			handle, processSpec, _ := wardenConn.RunArgsForCall(0)
 			Expect(handle).To(Equal("fake-vm-id"))
-			Expect(processSpec).To(Equal(expectedProcessSpec))
+			Expect(processSpec.Path).To(Equal("bash"))
+			Expect(processSpec.User).To(Equal("root"))
+			Expect(processSpec.Args).To(HaveLen(2))
+			Expect(processSpec.Args[0]).To(Equal("-c"))
+			Expect(processSpec.Args[1]).To(MatchRegexp(
+				`^cp /fake-download-path/file\.ext /tmp/file-[0-9a-f]+\.ext && chown vcap:vcap /tmp/file-[0-9a-f]+\.ext$`,
+			))
 		})
 
 		Context("when copying agent env into temporary location succeeds", func() {
@@ -221,7 +219,7 @@ var _ = Describe("WardenFileService", func() {
 
 					handle, spec := wardenConn.StreamOutArgsForCall(0)
 					Expect(handle).To(Equal("fake-vm-id"))
-					Expect(spec.Path).To(Equal("/tmp/file.ext"))
+					Expect(spec.Path).To(MatchRegexp(`^/tmp/file-[0-9a-f]+\.ext$`))
 					Expect(spec.User).To(Equal("root"))
 				})
 			})


### PR DESCRIPTION
**The problem:** Both Upload and Download in warden_file_service.go used same temp file paths (e.g. /tmp/warden-cpi-user-data.json). This causes race conditions when VMs are created concurrently.

**The fix:** Added a uniqueTmpFileName helper that appends 8 random bytes to the base filename before the extension. For example, warden-cpi-user-data.json becomes warden-cpi-user-data-a1b2c3d4e5f6a7b8.json.

Fixes: https://github.com/cloudfoundry/bosh-warden-cpi-release/issues/33