### PR TITLE
Remove host cgroup bind mount

### DIFF
--- a/src/bosh-warden-cpi/vm/warden_creator.go
+++ b/src/bosh-warden-cpi/vm/warden_creator.go
@@ -117,14 +117,14 @@ func (c WardenCreator) Create(
 		Privileged: true,
 	}
 
-	if c.Config.StartContainersWithSystemD {
-		containerSpec.BindMounts = append(containerSpec.BindMounts, wrdn.BindMount{
-			SrcPath: "/sys/fs/cgroup",
-			DstPath: "/sys/fs/cgroup",
-			Mode:    wrdn.BindMountModeRW,
-			Origin:  wrdn.BindMountOriginHost,
-		})
-	}
+	//if c.Config.StartContainersWithSystemD {
+	//	containerSpec.BindMounts = append(containerSpec.BindMounts, wrdn.BindMount{
+	//		SrcPath: "/sys/fs/cgroup",
+	//		DstPath: "/sys/fs/cgroup",
+	//		Mode:    wrdn.BindMountModeRW,
+	//		Origin:  wrdn.BindMountOriginHost,
+	//	})
+	//}
 
 	c.logger.Debug("WardenCreator", "Creating container with spec %#v", containerSpec)
 


### PR DESCRIPTION
* Bind-mounting the host's /sys/fs/cgroup into the container is incompatible with cgroup namespace isolation (NEWCGROUP)