### PR TITLE
warden-cpi now makes bosh director worker bpm containers privileged

### DIFF
--- a/jobs/warden_cpi/templates/pre-start.erb
+++ b/jobs/warden_cpi/templates/pre-start.erb
@@ -7,3 +7,10 @@ sed -i 's/\/var\/vcap\/data\/garden\/bin\/init/\/sbin\/init/' /var/vcap/jobs/gar
 <% else %>
 sed -i 's/\/sbin\/init/\/var\/vcap\/data\/garden\/bin\/init/' /var/vcap/jobs/garden/config/config.ini
 <% end %>
+
+# Patch the director's BPM config to grant worker processes privileged mode so
+# that the warden CPI can perform bind mounts and iptables calls from within
+# the BPM container. This is intentionally hacky - we're confining the hack to
+# warden-cpi instead of polluting the director release. Our intention is to
+# deprecate the warden-cpi in favor of the docker-cpi.
+/var/vcap/packages/warden_cpi/bin/bpm-patcher

--- a/jobs/warden_cpi/templates/pre-start.erb
+++ b/jobs/warden_cpi/templates/pre-start.erb
@@ -3,9 +3,20 @@
 set -eu
 
 <% if p("warden_cpi.start_containers_with_systemd") %>
-sed -i 's/\/var\/vcap\/data\/garden\/bin\/init/\/sbin\/init/' /var/vcap/jobs/garden/config/config.ini
+# Garden bind-mounts init-bin from the HOST into every container as /tmp/garden-init
+# and runs it as PID 1. If init-bin were the host's /sbin/init (e.g. Noble systemd),
+# its internal shared libraries (libsystemd-shared-N.so) would be resolved from
+# the CONTAINER's rootfs -- failing whenever the container's stemcell carries a
+# different systemd version (e.g. Resolute ships systemd 259, Noble ships 255).
+#
+# The wrapper script below exec's /sbin/init from *inside* the container, so each
+# stemcell uses its own systemd version and finds its own matching libraries.
+printf '%s\n' '#!/bin/sh' 'exec /sbin/init "$@"' > /var/vcap/data/garden/bin/exec-container-init
+chmod +x /var/vcap/data/garden/bin/exec-container-init
+
+sed -i 's|init-bin = /var/vcap/data/garden/bin/init|init-bin = /var/vcap/data/garden/bin/exec-container-init|' /var/vcap/jobs/garden/config/config.ini
 <% else %>
-sed -i 's/\/sbin\/init/\/var\/vcap\/data\/garden\/bin\/init/' /var/vcap/jobs/garden/config/config.ini
+sed -i 's|/sbin/init|/var/vcap/data/garden/bin/init|' /var/vcap/jobs/garden/config/config.ini
 <% end %>
 
 # Patch the director's BPM config to grant worker processes privileged mode so

--- a/packages/warden_cpi/packaging
+++ b/packages/warden_cpi/packaging
@@ -20,3 +20,4 @@ mkdir -p ${BOSH_INSTALL_TARGET}/bin
 export GOARCH=amd64
 export GOOS=linux
 go build -o "${BOSH_INSTALL_TARGET}/bin/cpi" ./main
+go build -o "${BOSH_INSTALL_TARGET}/bin/bpm-patcher" ./cmd/bpm-patcher

--- a/src/bosh-warden-cpi/cmd/bpm-patcher/main.go
+++ b/src/bosh-warden-cpi/cmd/bpm-patcher/main.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	yaml "go.yaml.in/yaml/v3"
+)
+
+const (
+	bpmYMLPath    = "/var/vcap/jobs/director/config/bpm.yml"
+	headerComment = "THIS YAML HAS BEEN HACKILY MODIFIED BY THE WARDEN CPI"
+)
+
+func main() {
+	path := bpmYMLPath
+	if len(os.Args) > 1 {
+		path = os.Args[1]
+	}
+
+	if err := patchBPMYML(path); err != nil {
+		fmt.Fprintf(os.Stderr, "bpm-patcher: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func patchBPMYML(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "bpm-patcher: %s not found, skipping\n", path)
+			return nil
+		}
+		return fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return fmt.Errorf("parsing %s: %w", path, err)
+	}
+
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
+		return fmt.Errorf("unexpected YAML structure in %s", path)
+	}
+
+	if doc.HeadComment == "" {
+		doc.HeadComment = headerComment
+	}
+
+	root := doc.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return fmt.Errorf("expected mapping at root of %s", path)
+	}
+
+	processesNode := findMappingValue(root, "processes")
+	if processesNode == nil || processesNode.Kind != yaml.SequenceNode {
+		fmt.Fprintf(os.Stderr, "bpm-patcher: could not find 'processes' sequence in %s, skipping\n", path)
+		return nil
+	}
+
+	patched := 0
+	for _, process := range processesNode.Content {
+		if process.Kind != yaml.MappingNode {
+			continue
+		}
+		nameNode := findMappingValue(process, "name")
+		if nameNode == nil {
+			continue
+		}
+		if isWorkerProcess(nameNode.Value) {
+			setPrivileged(process)
+			patched++
+		}
+	}
+
+	fmt.Printf("bpm-patcher: patched %d worker process(es) in %s\n", patched, path)
+
+	out, err := yaml.Marshal(&doc)
+	if err != nil {
+		return fmt.Errorf("marshaling YAML: %w", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", path, err)
+	}
+
+	if err := os.WriteFile(path, out, info.Mode()); err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+
+	return nil
+}
+
+// isWorkerProcess returns true for any director worker process that runs CPI
+// calls: normal workers (worker_N) and dynamic disk workers (dynamic_disks_worker_N).
+func isWorkerProcess(name string) bool {
+	return strings.HasPrefix(name, "worker_") || strings.HasPrefix(name, "dynamic_disks_worker_")
+}
+
+func findMappingValue(node *yaml.Node, key string) *yaml.Node {
+	if node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// setPrivileged adds unsafe.privileged: true to a BPM process node.
+// It is idempotent — running it twice on the same node is safe.
+func setPrivileged(process *yaml.Node) {
+	unsafeNode := findMappingValue(process, "unsafe")
+	if unsafeNode == nil {
+		process.Content = append(process.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "unsafe"},
+			&yaml.Node{
+				Kind: yaml.MappingNode,
+				Content: []*yaml.Node{
+					{Kind: yaml.ScalarNode, Tag: "!!str", Value: "privileged"},
+					{Kind: yaml.ScalarNode, Tag: "!!bool", Value: "true"},
+				},
+			},
+		)
+		return
+	}
+
+	// If the unsafe value exists but is not a mapping (unexpected schema),
+	// replace it with a fresh mapping containing just privileged: true.
+	if unsafeNode.Kind != yaml.MappingNode {
+		unsafeNode.Kind = yaml.MappingNode
+		unsafeNode.Tag = ""
+		unsafeNode.Value = ""
+		unsafeNode.Content = []*yaml.Node{
+			{Kind: yaml.ScalarNode, Tag: "!!str", Value: "privileged"},
+			{Kind: yaml.ScalarNode, Tag: "!!bool", Value: "true"},
+		}
+		return
+	}
+
+	privilegedNode := findMappingValue(unsafeNode, "privileged")
+	if privilegedNode == nil {
+		// Prepend so privileged: true is the first key in the unsafe block.
+		unsafeNode.Content = append(
+			[]*yaml.Node{
+				{Kind: yaml.ScalarNode, Tag: "!!str", Value: "privileged"},
+				{Kind: yaml.ScalarNode, Tag: "!!bool", Value: "true"},
+			},
+			unsafeNode.Content...,
+		)
+	} else {
+		privilegedNode.Value = "true"
+		privilegedNode.Tag = "!!bool"
+	}
+}

--- a/src/bosh-warden-cpi/cmd/bpm-patcher/main_suite_test.go
+++ b/src/bosh-warden-cpi/cmd/bpm-patcher/main_suite_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestBpmPatcher(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "BpmPatcher Suite")
+}

--- a/src/bosh-warden-cpi/cmd/bpm-patcher/main_test.go
+++ b/src/bosh-warden-cpi/cmd/bpm-patcher/main_test.go
@@ -1,0 +1,297 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	yaml "go.yaml.in/yaml/v3"
+)
+
+// minimalBPMYML is a representative director bpm.yml with worker and
+// non-worker processes, and an existing unsafe block on one worker.
+const minimalBPMYML = `processes:
+- name: director
+  executable: /var/vcap/packages/director/bin/bosh-director
+- name: worker_0
+  executable: /var/vcap/packages/director/bin/bosh-director-worker
+- name: worker_1
+  executable: /var/vcap/packages/director/bin/bosh-director-worker
+- name: dynamic_disks_worker_0
+  executable: /var/vcap/packages/director/bin/bosh-director-worker
+- name: worker_with_existing_unsafe
+  executable: /var/vcap/packages/director/bin/bosh-director-worker
+  unsafe:
+    unrestricted_volumes:
+    - path: /var/vcap/data
+`
+
+func writeTempBPM(dir, content string) string {
+	path := filepath.Join(dir, "bpm.yml")
+	Expect(os.WriteFile(path, []byte(content), 0644)).To(Succeed())
+	return path
+}
+
+func parseBPM(path string) *yaml.Node {
+	data, err := os.ReadFile(path)
+	Expect(err).NotTo(HaveOccurred())
+	var doc yaml.Node
+	Expect(yaml.Unmarshal(data, &doc)).To(Succeed())
+	return &doc
+}
+
+var _ = Describe("patchBPMYML", func() {
+	var tmpDir string
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "bpm-patcher-test-*")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(tmpDir)).To(Succeed())
+	})
+
+	Context("when the file does not exist", func() {
+		It("succeeds without error", func() {
+			err := patchBPMYML(filepath.Join(tmpDir, "nonexistent.yml"))
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("when the YAML root is not a mapping", func() {
+		It("returns an error", func() {
+			path := writeTempBPM(tmpDir, "- item1\n- item2\n")
+			err := patchBPMYML(path)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("expected mapping at root"))
+		})
+	})
+
+	Context("when 'processes' is absent", func() {
+		It("succeeds without error (soft-skip)", func() {
+			path := writeTempBPM(tmpDir, "some_other_key: value\n")
+			Expect(patchBPMYML(path)).To(Succeed())
+		})
+	})
+
+	Context("when 'processes' is not a sequence", func() {
+		It("succeeds without error (soft-skip)", func() {
+			path := writeTempBPM(tmpDir, "processes: not-a-list\n")
+			Expect(patchBPMYML(path)).To(Succeed())
+		})
+	})
+
+	Context("with a valid bpm.yml", func() {
+		It("sets unsafe.privileged on every worker process", func() {
+			path := writeTempBPM(tmpDir, minimalBPMYML)
+			Expect(patchBPMYML(path)).To(Succeed())
+
+			doc := parseBPM(path)
+			root := doc.Content[0]
+			processes := findMappingValue(root, "processes")
+			Expect(processes).NotTo(BeNil())
+
+			for _, proc := range processes.Content {
+				name := findMappingValue(proc, "name")
+				Expect(name).NotTo(BeNil())
+
+				unsafe := findMappingValue(proc, "unsafe")
+				if isWorkerProcess(name.Value) {
+					Expect(unsafe).NotTo(BeNil(), "expected unsafe block on %s", name.Value)
+					priv := findMappingValue(unsafe, "privileged")
+					Expect(priv).NotTo(BeNil(), "expected privileged key on %s", name.Value)
+					Expect(priv.Value).To(Equal("true"))
+				} else {
+					// non-worker processes must not gain an unsafe block
+					if unsafe != nil {
+						priv := findMappingValue(unsafe, "privileged")
+						Expect(priv).To(BeNil(), "director must not be privileged")
+					}
+				}
+			}
+		})
+
+		It("preserves existing unsafe keys on a worker", func() {
+			path := writeTempBPM(tmpDir, minimalBPMYML)
+			Expect(patchBPMYML(path)).To(Succeed())
+
+			doc := parseBPM(path)
+			root := doc.Content[0]
+			processes := findMappingValue(root, "processes")
+
+			var workerWithExisting *yaml.Node
+			for _, proc := range processes.Content {
+				name := findMappingValue(proc, "name")
+				if name != nil && name.Value == "worker_with_existing_unsafe" {
+					workerWithExisting = proc
+					break
+				}
+			}
+			Expect(workerWithExisting).NotTo(BeNil())
+
+			unsafe := findMappingValue(workerWithExisting, "unsafe")
+			Expect(unsafe).NotTo(BeNil())
+			Expect(findMappingValue(unsafe, "privileged").Value).To(Equal("true"))
+			Expect(findMappingValue(unsafe, "unrestricted_volumes")).NotTo(BeNil(),
+				"pre-existing unsafe keys must be preserved")
+		})
+
+		It("adds the header comment", func() {
+			path := writeTempBPM(tmpDir, minimalBPMYML)
+			Expect(patchBPMYML(path)).To(Succeed())
+
+			data, err := os.ReadFile(path)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(data)).To(ContainSubstring(headerComment))
+		})
+
+		It("is idempotent — a second call does not double-add unsafe", func() {
+			path := writeTempBPM(tmpDir, minimalBPMYML)
+			Expect(patchBPMYML(path)).To(Succeed())
+			firstContent, err := os.ReadFile(path)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(patchBPMYML(path)).To(Succeed())
+			secondContent, err := os.ReadFile(path)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(string(secondContent)).To(Equal(string(firstContent)))
+		})
+	})
+})
+
+var _ = Describe("isWorkerProcess", func() {
+	DescribeTable("worker names",
+		func(name string, expected bool) {
+			Expect(isWorkerProcess(name)).To(Equal(expected))
+		},
+		Entry("worker_0", "worker_0", true),
+		Entry("worker_99", "worker_99", true),
+		Entry("dynamic_disks_worker_0", "dynamic_disks_worker_0", true),
+		Entry("dynamic_disks_worker_1", "dynamic_disks_worker_1", true),
+		Entry("director", "director", false),
+		Entry("health_monitor", "health_monitor", false),
+		Entry("worker (no underscore suffix)", "worker", false),
+		Entry("dynamic_disks_worker (no suffix)", "dynamic_disks_worker", false),
+	)
+})
+
+var _ = Describe("findMappingValue", func() {
+	It("returns the value node for a present key", func() {
+		node := &yaml.Node{
+			Kind: yaml.MappingNode,
+			Content: []*yaml.Node{
+				{Kind: yaml.ScalarNode, Value: "foo"},
+				{Kind: yaml.ScalarNode, Value: "bar"},
+			},
+		}
+		result := findMappingValue(node, "foo")
+		Expect(result).NotTo(BeNil())
+		Expect(result.Value).To(Equal("bar"))
+	})
+
+	It("returns nil for a missing key", func() {
+		node := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{}}
+		Expect(findMappingValue(node, "missing")).To(BeNil())
+	})
+
+	It("returns nil for a non-mapping node", func() {
+		node := &yaml.Node{Kind: yaml.SequenceNode}
+		Expect(findMappingValue(node, "foo")).To(BeNil())
+	})
+})
+
+var _ = Describe("setPrivileged", func() {
+	buildProcess := func(extraContent ...*yaml.Node) *yaml.Node {
+		base := []*yaml.Node{
+			{Kind: yaml.ScalarNode, Value: "name"},
+			{Kind: yaml.ScalarNode, Value: "worker_0"},
+			{Kind: yaml.ScalarNode, Value: "executable"},
+			{Kind: yaml.ScalarNode, Value: "/path/to/binary"},
+		}
+		return &yaml.Node{Kind: yaml.MappingNode, Content: append(base, extraContent...)}
+	}
+
+	Context("process has no unsafe block", func() {
+		It("adds unsafe.privileged: true", func() {
+			proc := buildProcess()
+			setPrivileged(proc)
+
+			unsafe := findMappingValue(proc, "unsafe")
+			Expect(unsafe).NotTo(BeNil())
+			Expect(findMappingValue(unsafe, "privileged").Value).To(Equal("true"))
+		})
+	})
+
+	Context("process has unsafe block without privileged key", func() {
+		It("prepends privileged: true to the existing unsafe block", func() {
+			proc := buildProcess(
+				&yaml.Node{Kind: yaml.ScalarNode, Value: "unsafe"},
+				&yaml.Node{
+					Kind: yaml.MappingNode,
+					Content: []*yaml.Node{
+						{Kind: yaml.ScalarNode, Value: "unrestricted_volumes"},
+						{Kind: yaml.SequenceNode},
+					},
+				},
+			)
+			setPrivileged(proc)
+
+			unsafe := findMappingValue(proc, "unsafe")
+			Expect(findMappingValue(unsafe, "privileged").Value).To(Equal("true"))
+			Expect(findMappingValue(unsafe, "unrestricted_volumes")).NotTo(BeNil(),
+				"existing keys must be preserved")
+		})
+	})
+
+	Context("process has unsafe.privileged: false", func() {
+		It("sets it to true", func() {
+			proc := buildProcess(
+				&yaml.Node{Kind: yaml.ScalarNode, Value: "unsafe"},
+				&yaml.Node{
+					Kind: yaml.MappingNode,
+					Content: []*yaml.Node{
+						{Kind: yaml.ScalarNode, Value: "privileged"},
+						{Kind: yaml.ScalarNode, Tag: "!!bool", Value: "false"},
+					},
+				},
+			)
+			setPrivileged(proc)
+
+			unsafe := findMappingValue(proc, "unsafe")
+			Expect(findMappingValue(unsafe, "privileged").Value).To(Equal("true"))
+		})
+	})
+
+	Context("called twice on the same process", func() {
+		It("is idempotent", func() {
+			proc := buildProcess()
+			setPrivileged(proc)
+			setPrivileged(proc)
+
+			unsafe := findMappingValue(proc, "unsafe")
+			Expect(unsafe).NotTo(BeNil())
+			Expect(findMappingValue(unsafe, "privileged").Value).To(Equal("true"))
+			// unsafe block should only have the one key
+			Expect(unsafe.Content).To(HaveLen(2))
+		})
+	})
+
+	Context("process has a malformed unsafe block (not a mapping)", func() {
+		It("replaces it with a valid unsafe.privileged: true mapping", func() {
+			proc := buildProcess(
+				&yaml.Node{Kind: yaml.ScalarNode, Value: "unsafe"},
+				&yaml.Node{Kind: yaml.ScalarNode, Value: "some-unexpected-scalar"},
+			)
+			setPrivileged(proc)
+
+			unsafe := findMappingValue(proc, "unsafe")
+			Expect(unsafe).NotTo(BeNil())
+			Expect(unsafe.Kind).To(Equal(yaml.MappingNode))
+			Expect(findMappingValue(unsafe, "privileged").Value).To(Equal("true"))
+		})
+	})
+})


### PR DESCRIPTION
With the move to running director workers in BPM the warden cpi can no longer call sudo so can't invoke iptables or mount. We do not want to pollute the director with hacks to make the warden CPI work, as our intention is to deprecate the warden cpi in favor of the docker cpi.

The patching is done via a small golang executable which leaves a comment at the top of the bpm.yml that it has been modified.