### PR TITLE
director worker bpm fixes - mounts, user

### DIFF
--- a/jobs/warden_cpi/templates/pre-start.erb
+++ b/jobs/warden_cpi/templates/pre-start.erb
@@ -23,6 +23,17 @@ sed -i 's|init-bin = /var/vcap/data/garden/bin/init|init-bin = /var/vcap/data/ga
 sed -i 's|init-bin = /var/vcap/data/garden/bin/exec-container-init|init-bin = /var/vcap/data/garden/bin/init|' /var/vcap/jobs/garden/config/config.ini
 <% end %>
 
+# Pre-create the warden_cpi store directories on the persistent disk before BPM
+# starts the director workers. When the director worker BPM config specifies
+# /var/vcap/store/warden_cpi as an unrestricted_volume, BPM bind-mounts the
+# source path into the container. If the source path does not exist on the real
+# persistent disk at bind-mount time, BPM silently creates an empty directory
+# as the bind-mount source, and that directory is backed by the rootfs overlay
+# rather than the persistent disk. 
+# ensures the bind-mount source is a real persistent-disk path.
+mkdir -p /var/vcap/store/warden_cpi/
+chown -R vcap:vcap /var/vcap/store/warden_cpi
+
 # Patch the director's BPM config to grant worker processes privileged mode so
 # that the warden CPI can perform bind mounts and iptables calls from within
 # the BPM container. This is intentionally hacky - we're confining the hack to

--- a/src/bosh-warden-cpi/cmd/bpm-patcher/main.go
+++ b/src/bosh-warden-cpi/cmd/bpm-patcher/main.go
@@ -70,6 +70,7 @@ func patchBPMYML(path string) error {
 		}
 		if isWorkerProcess(nameNode.Value) {
 			setPrivileged(process)
+			setWorkerCommand(process)
 			patched++
 		}
 	}
@@ -93,10 +94,95 @@ func patchBPMYML(path string) error {
 	return nil
 }
 
+// setMappingScalar sets an existing scalar key-value pair in a mapping node,
+// or appends a new key-value pair if the key is not present. It is safe to
+// call on any scalar-valued key regardless of the node's original tag or style.
+func setMappingScalar(node *yaml.Node, key, value string) {
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			v := node.Content[i+1]
+			v.Kind = yaml.ScalarNode
+			v.Tag = "!!str"
+			v.Value = value
+			v.Content = nil
+			return
+		}
+	}
+	node.Content = append(node.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key},
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value},
+	)
+}
+
+// setWorkerCommand rewrites the executable and args of a worker process node so
+// that the BPM container runs privileged (giving the CPI root for iptables/mount)
+// while the worker process itself drops back to the vcap user via setpriv,
+// preventing root-owned files from being written into /var/vcap/data/director.
+// The original executable and any existing args are forwarded unchanged through
+// the setpriv invocation. The transformation is idempotent — if the process
+// already has /usr/bin/bash as its executable it has already been patched and
+// is left as-is.
+func setWorkerCommand(process *yaml.Node) {
+	exeNode := findMappingValue(process, "executable")
+
+	// Already patched — the executable has already been replaced with bash.
+	if exeNode != nil && exeNode.Value == "/usr/bin/bash" {
+		return
+	}
+
+	// Capture the original executable and any existing args so they can be
+	// forwarded through the setpriv invocation unchanged.  Each token is
+	// single-quote escaped so that values containing spaces or shell
+	// metacharacters survive the bash -c evaluation intact.
+	var parts []string
+	parts = append(parts, "exec setpriv --reuid=vcap --regid=vcap --clear-groups --")
+	if exeNode != nil && exeNode.Value != "" {
+		parts = append(parts, shellQuote(exeNode.Value))
+	}
+	argsNode := findMappingValue(process, "args")
+	if argsNode != nil && argsNode.Kind == yaml.SequenceNode {
+		for _, arg := range argsNode.Content {
+			if arg.Kind == yaml.ScalarNode {
+				parts = append(parts, shellQuote(arg.Value))
+			}
+		}
+	}
+
+	execCmd := strings.Join(parts, " ")
+	setMappingScalar(process, "executable", "/usr/bin/bash")
+
+	newArgs := &yaml.Node{
+		Kind: yaml.SequenceNode,
+		Tag:  "!!seq",
+		Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Tag: "!!str", Value: "-c"},
+			{Kind: yaml.ScalarNode, Tag: "!!str", Value: execCmd},
+		},
+	}
+
+	for i := 0; i+1 < len(process.Content); i += 2 {
+		if process.Content[i].Value == "args" {
+			process.Content[i+1] = newArgs
+			return
+		}
+	}
+	process.Content = append(process.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "args"},
+		newArgs,
+	)
+}
+
 // isWorkerProcess returns true for any director worker process that runs CPI
 // calls: normal workers (worker_N) and dynamic disk workers (dynamic_disks_worker_N).
 func isWorkerProcess(name string) bool {
 	return strings.HasPrefix(name, "worker_") || strings.HasPrefix(name, "dynamic_disks_worker_")
+}
+
+// shellQuote wraps s in single quotes and escapes any embedded single quotes
+// so the value survives evaluation by bash -c as a single word, regardless of
+// spaces or shell metacharacters it may contain.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 func findMappingValue(node *yaml.Node, key string) *yaml.Node {

--- a/src/bosh-warden-cpi/cmd/bpm-patcher/main_test.go
+++ b/src/bosh-warden-cpi/cmd/bpm-patcher/main_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 // minimalBPMYML is a representative director bpm.yml with worker and
-// non-worker processes, and an existing unsafe block on one worker.
+// non-worker processes, an existing unsafe block on one worker, and a worker
+// that already has an executable and args (to exercise replacement logic).
 const minimalBPMYML = `processes:
 - name: director
   executable: /var/vcap/packages/director/bin/bosh-director
@@ -25,6 +26,11 @@ const minimalBPMYML = `processes:
   unsafe:
     unrestricted_volumes:
     - path: /var/vcap/data
+- name: worker_with_existing_args
+  executable: /some/old/executable
+  args:
+  - --old-arg
+  - --another-old-arg
 `
 
 func writeTempBPM(dir, content string) string {
@@ -85,7 +91,7 @@ var _ = Describe("patchBPMYML", func() {
 	})
 
 	Context("with a valid bpm.yml", func() {
-		It("sets unsafe.privileged on every worker process", func() {
+		It("sets unsafe.privileged and setpriv command on every worker process", func() {
 			path := writeTempBPM(tmpDir, minimalBPMYML)
 			Expect(patchBPMYML(path)).To(Succeed())
 
@@ -104,14 +110,55 @@ var _ = Describe("patchBPMYML", func() {
 					priv := findMappingValue(unsafe, "privileged")
 					Expect(priv).NotTo(BeNil(), "expected privileged key on %s", name.Value)
 					Expect(priv.Value).To(Equal("true"))
+
+					exe := findMappingValue(proc, "executable")
+					Expect(exe).NotTo(BeNil(), "expected executable on %s", name.Value)
+					Expect(exe.Value).To(Equal("/usr/bin/bash"), "executable on %s", name.Value)
+
+					argsNode := findMappingValue(proc, "args")
+					Expect(argsNode).NotTo(BeNil(), "expected args on %s", name.Value)
+					Expect(argsNode.Kind).To(Equal(yaml.SequenceNode))
+					Expect(argsNode.Content).To(HaveLen(2))
+					Expect(argsNode.Content[0].Value).To(Equal("-c"))
+					Expect(argsNode.Content[1].Value).To(ContainSubstring("setpriv"))
 				} else {
-					// non-worker processes must not gain an unsafe block
+					// non-worker processes must not gain an unsafe block or altered executable
 					if unsafe != nil {
 						priv := findMappingValue(unsafe, "privileged")
 						Expect(priv).To(BeNil(), "director must not be privileged")
 					}
+					exe := findMappingValue(proc, "executable")
+					Expect(exe).NotTo(BeNil())
+					Expect(exe.Value).NotTo(Equal("/usr/bin/bash"), "director executable must not be rewritten")
 				}
 			}
+		})
+
+		It("preserves the original executable and args inside the setpriv command", func() {
+			path := writeTempBPM(tmpDir, minimalBPMYML)
+			Expect(patchBPMYML(path)).To(Succeed())
+
+			doc := parseBPM(path)
+			root := doc.Content[0]
+			processes := findMappingValue(root, "processes")
+
+			var target *yaml.Node
+			for _, proc := range processes.Content {
+				name := findMappingValue(proc, "name")
+				if name != nil && name.Value == "worker_with_existing_args" {
+					target = proc
+					break
+				}
+			}
+			Expect(target).NotTo(BeNil())
+
+			argsNode := findMappingValue(target, "args")
+			Expect(argsNode).NotTo(BeNil())
+			cmd := argsNode.Content[1].Value
+			Expect(cmd).To(ContainSubstring("setpriv"))
+			Expect(cmd).To(ContainSubstring("/some/old/executable"))
+			Expect(cmd).To(ContainSubstring("--old-arg"))
+			Expect(cmd).To(ContainSubstring("--another-old-arg"))
 		})
 
 		It("preserves existing unsafe keys on a worker", func() {
@@ -201,6 +248,121 @@ var _ = Describe("findMappingValue", func() {
 	It("returns nil for a non-mapping node", func() {
 		node := &yaml.Node{Kind: yaml.SequenceNode}
 		Expect(findMappingValue(node, "foo")).To(BeNil())
+	})
+})
+
+var _ = Describe("setWorkerCommand", func() {
+	buildProcess := func(extraContent ...*yaml.Node) *yaml.Node {
+		base := []*yaml.Node{
+			{Kind: yaml.ScalarNode, Value: "name"},
+			{Kind: yaml.ScalarNode, Value: "worker_0"},
+			{Kind: yaml.ScalarNode, Value: "executable"},
+			{Kind: yaml.ScalarNode, Value: "/var/vcap/packages/director/bin/bosh-director-worker"},
+		}
+		return &yaml.Node{Kind: yaml.MappingNode, Content: append(base, extraContent...)}
+	}
+
+	It("sets executable to /usr/bin/bash", func() {
+		proc := buildProcess()
+		setWorkerCommand(proc)
+		exe := findMappingValue(proc, "executable")
+		Expect(exe).NotTo(BeNil())
+		Expect(exe.Value).To(Equal("/usr/bin/bash"))
+	})
+
+	It("wraps the original executable in a setpriv command", func() {
+		proc := buildProcess()
+		setWorkerCommand(proc)
+		args := findMappingValue(proc, "args")
+		Expect(args).NotTo(BeNil())
+		Expect(args.Kind).To(Equal(yaml.SequenceNode))
+		Expect(args.Content).To(HaveLen(2))
+		Expect(args.Content[0].Value).To(Equal("-c"))
+		Expect(args.Content[1].Value).To(ContainSubstring("setpriv"))
+		Expect(args.Content[1].Value).To(ContainSubstring("/var/vcap/packages/director/bin/bosh-director-worker"))
+	})
+
+	Context("process has existing args", func() {
+		It("forwards existing args through the setpriv command", func() {
+			proc := buildProcess(
+				&yaml.Node{Kind: yaml.ScalarNode, Value: "args"},
+				&yaml.Node{
+					Kind: yaml.SequenceNode,
+					Content: []*yaml.Node{
+						{Kind: yaml.ScalarNode, Value: "worker_0"},
+						{Kind: yaml.ScalarNode, Value: "--extra-flag"},
+					},
+				},
+			)
+			setWorkerCommand(proc)
+
+			args := findMappingValue(proc, "args")
+			Expect(args.Content).To(HaveLen(2))
+			cmd := args.Content[1].Value
+			Expect(cmd).To(ContainSubstring("setpriv"))
+			Expect(cmd).To(ContainSubstring("/var/vcap/packages/director/bin/bosh-director-worker"))
+			Expect(cmd).To(ContainSubstring("worker_0"))
+			Expect(cmd).To(ContainSubstring("--extra-flag"))
+		})
+	})
+
+	Context("process has an arg that contains spaces", func() {
+		It("shell-quotes the arg so it survives bash -c as a single word", func() {
+			proc := buildProcess(
+				&yaml.Node{Kind: yaml.ScalarNode, Value: "args"},
+				&yaml.Node{
+					Kind: yaml.SequenceNode,
+					Content: []*yaml.Node{
+						{Kind: yaml.ScalarNode, Value: "hello world"},
+					},
+				},
+			)
+			setWorkerCommand(proc)
+
+			args := findMappingValue(proc, "args")
+			Expect(args.Content).To(HaveLen(2))
+			cmd := args.Content[1].Value
+			// The space-containing arg must appear quoted so bash treats it as one token.
+			Expect(cmd).To(ContainSubstring("'hello world'"))
+		})
+	})
+
+	Context("called twice on the same process", func() {
+		It("is idempotent — does not wrap setpriv inside itself", func() {
+			proc := buildProcess()
+			setWorkerCommand(proc)
+			firstCmd := findMappingValue(proc, "args").Content[1].Value
+
+			setWorkerCommand(proc)
+			args := findMappingValue(proc, "args")
+			Expect(args.Content).To(HaveLen(2), "args must not be duplicated")
+			Expect(args.Content[1].Value).To(Equal(firstCmd),
+				"second call must not re-wrap the setpriv command")
+		})
+	})
+})
+
+var _ = Describe("setMappingScalar", func() {
+	It("adds a new key when absent", func() {
+		node := &yaml.Node{Kind: yaml.MappingNode}
+		setMappingScalar(node, "foo", "bar")
+		result := findMappingValue(node, "foo")
+		Expect(result).NotTo(BeNil())
+		Expect(result.Value).To(Equal("bar"))
+	})
+
+	It("updates an existing key in place", func() {
+		node := &yaml.Node{
+			Kind: yaml.MappingNode,
+			Content: []*yaml.Node{
+				{Kind: yaml.ScalarNode, Value: "foo"},
+				{Kind: yaml.ScalarNode, Value: "old"},
+			},
+		}
+		setMappingScalar(node, "foo", "new")
+		result := findMappingValue(node, "foo")
+		Expect(result.Value).To(Equal("new"))
+		Expect(node.Content).To(HaveLen(2), "must not append a duplicate key")
 	})
 })
 

--- a/src/bosh-warden-cpi/vm/fs_host_bind_mounts.go
+++ b/src/bosh-warden-cpi/vm/fs_host_bind_mounts.go
@@ -77,7 +77,16 @@ func (hbm FSHostBindMounts) DeleteEphemeral(id apiv1.VMCID) error {
 		return nil
 	}
 
-	_, _, _, err := hbm.cmdRunner.RunCommand("umount", path)
+	// With shared: true on the BPM unrestricted_volume for /var/vcap/store/warden_cpi,
+	// the mount --bind in MakeEphemeral propagates to the host namespace as a shared
+	// mount. Garden then binds that host-side path into the VM container as
+	// /var/vcap/data. Any mounts made inside the container (e.g. a systemd tmpfs at
+	// /run, visible as /var/vcap/data/sys/run) propagate back to the host through the
+	// shared mount, appearing as nested mounts under this path. A plain umount only
+	// removes the top-level self-bind mount and leaves nested mounts in place,
+	// causing the subsequent RemoveAll to fail with "device or resource busy".
+	// umount --recursive tears down the entire mount tree before we delete.
+	_, _, _, err := hbm.cmdRunner.RunCommand("umount", "--recursive", path)
 	if err != nil && !strings.Contains(err.Error(), "not mounted") {
 		return err
 	}

--- a/src/bosh-warden-cpi/vm/fs_host_bind_mounts_test.go
+++ b/src/bosh-warden-cpi/vm/fs_host_bind_mounts_test.go
@@ -137,7 +137,7 @@ var _ = Describe("FSHostBindMounts", func() {
 			Context("when unmounting fails because it is not mounted", func() {
 				BeforeEach(func() {
 					cmdRunner.AddCmdResult(
-						"umount /fake-ephemeral-dir/fake-id",
+						"umount --recursive /fake-ephemeral-dir/fake-id",
 						fakesys.FakeCmdResult{Error: errors.New("not mounted")},
 					)
 				})
@@ -153,7 +153,7 @@ var _ = Describe("FSHostBindMounts", func() {
 			Context("when unmounting directory fails", func() {
 				BeforeEach(func() {
 					cmdRunner.AddCmdResult(
-						"umount /fake-ephemeral-dir/fake-id",
+						"umount --recursive /fake-ephemeral-dir/fake-id",
 						fakesys.FakeCmdResult{Error: errors.New("fake-run-err")},
 					)
 				})


### PR DESCRIPTION
The worker needs to run as vcap, specifically because the director also needs to read/write blobstore-config. But the warden-cpi needs to be able to sudo. So run in a privileged container, but use setpriv to run as vcap.

Make /var/vcap/data/warden_cpi directory in pre-start so that bpm can bind mount it into the director worker when it starts.

Recursively unmount volumes when deleting containers.