### PR TITLE
wip: make bind mounts shared

### DIFF
--- a/src/bosh-warden-cpi/vm/fs_host_bind_mounts.go
+++ b/src/bosh-warden-cpi/vm/fs_host_bind_mounts.go
@@ -55,9 +55,13 @@ func (hbm FSHostBindMounts) MakeEphemeral(id apiv1.VMCID) (string, error) {
 		return "", bosherr.WrapError(err, "Making ephemeral bind mount")
 	}
 
+	// --make-shared keeps this mount in the same peer group as the host-side
+	// copy so that container-internal mounts (e.g. systemd's /run tmpfs) that
+	// propagate to the host also propagate back into BPM's namespace, making
+	// them visible to umount --recursive in DeleteEphemeral.
 	mountArgss := [][]string{
 		[]string{"--bind", path, path},
-		[]string{"--make-private", path},
+		[]string{"--make-shared", path},
 	}
 
 	for _, mountArgs := range mountArgss {

--- a/src/bosh-warden-cpi/vm/fs_host_bind_mounts_test.go
+++ b/src/bosh-warden-cpi/vm/fs_host_bind_mounts_test.go
@@ -59,7 +59,7 @@ var _ = Describe("FSHostBindMounts", func() {
 		})
 
 		Context("when creating directory succeeds", func() {
-			It("makes the bind mount point private", func() {
+			It("makes the bind mount point shared", func() {
 				_, err := hostBindMounts.MakeEphemeral(apiv1.NewVMCID("fake-id"))
 				Expect(err).ToNot(HaveOccurred())
 
@@ -70,13 +70,13 @@ var _ = Describe("FSHostBindMounts", func() {
 						"/fake-ephemeral-dir/fake-id",
 					},
 					[]string{
-						"mount", "--make-private",
+						"mount", "--make-shared",
 						"/fake-ephemeral-dir/fake-id",
 					},
 				}))
 			})
 
-			Context("when making bind point private fails", func() {
+			Context("when making bind point shared fails", func() {
 				It("returns error if --bind fails", func() {
 					cmdRunner.AddCmdResult(
 						"mount --bind /fake-ephemeral-dir/fake-id /fake-ephemeral-dir/fake-id",
@@ -88,9 +88,9 @@ var _ = Describe("FSHostBindMounts", func() {
 					Expect(err.Error()).To(ContainSubstring("fake-run-err"))
 				})
 
-				It("returns error if --make-private fails", func() {
+				It("returns error if --make-shared fails", func() {
 					cmdRunner.AddCmdResult(
-						"mount --make-private /fake-ephemeral-dir/fake-id",
+						"mount --make-shared /fake-ephemeral-dir/fake-id",
 						fakesys.FakeCmdResult{Error: errors.New("fake-run-err")},
 					)
 


### PR DESCRIPTION
Workers now run inside BPM containers with unsafe.privileged: true.  BPM creates a new mount namespace for each worker; the /var/vcap/store/warden_cpi volume is mounted shared so that bind mounts created inside BPM propagate to the host namespace.

Previously MakeEphemeral used --make-private on the per-VM bind mount.  In a privileged BPM namespace the parent /var/vcap/store/warden_cpi mount is already shared (MS_SHARED), so Garden's bind of the per-VM path into a container sits in the same shared peer group.  systemd inside the container creates a tmpfs at /run; because the parent chain is shared, that mount propagates to the host namespace but NOT back to BPM's private bind mount. When DeleteEphemeral calls umount --recursive inside BPM, it misses the host-side /sys/run mount, so the subsequent RemoveAll fails with EBUSY.

Using --make-shared on the per-VM bind mount keeps it in the same peer group as the host-side copy.  Container-internal mounts then propagate to both the host and back into BPM, so umount --recursive sees the full mount tree and cleans it up successfully.